### PR TITLE
Fix: オプションを開くときの再帰を修正

### DIFF
--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -878,6 +878,9 @@ const currentAudioOutputDeviceComputed = computed<{
   label: string;
 } | null>({
   get: () => {
+    if (store.state.savingSetting.audioOutputDevice === "default") {
+      return null;
+    }
     // 再生デバイスが見つからなかったらデフォルト値に戻す
     const device = availableAudioOutputDevices.value?.find(
       (device) => device.key === store.state.savingSetting.audioOutputDevice


### PR DESCRIPTION
## 内容

オプションを開くときに再帰が発生していたのを修正します。こんな感じになってました：
- 画面表示
- currentAudioDeviceComputed（めんどくさいのでCADC）の計算
- handleSavingSettingChange（以下HSSC）の呼び出し
- 変数の更新による再描画
- CADCの計算
- HSSCの呼び出し

といった感じで無限ループします。


## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）