### PR TITLE
Update: Capacitor v5に更新

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -2,8 +2,8 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_11
-      targetCompatibility JavaVersion.VERSION_11
+      sourceCompatibility JavaVersion.VERSION_17
+      targetCompatibility JavaVersion.VERSION_17
   }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,8 +9,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath 'com.google.gms:google-services:4.3.13'
+        classpath 'com.android.tools.build:gradle:8.0.1'
+        classpath 'com.google.gms:google-services:4.3.15'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -30,3 +30,4 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -20,10 +20,9 @@ org.gradle.jvmargs=-Xmx4096M
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 kotlin.jvm.target.validation.mode=ignore
 org.gradle.unsafe.configuration-cache=true
+

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,16 +1,16 @@
 ext {
-    minSdkVersion = 26
-    compileSdkVersion = 32
-    targetSdkVersion = 32
-    androidxActivityVersion = '1.4.0'
-    androidxAppCompatVersion = '1.4.2'
+    minSdkVersion = 22
+    compileSdkVersion = 33
+    targetSdkVersion = 33
+    androidxActivityVersion = '1.7.0'
+    androidxAppCompatVersion = '1.6.1'
     androidxCoordinatorLayoutVersion = '1.2.0'
-    androidxCoreVersion = '1.8.0'
-    androidxFragmentVersion = '1.4.1'
-    coreSplashScreenVersion = '1.0.0-rc01'
-    androidxWebkitVersion = '1.4.0'
+    androidxCoreVersion = '1.10.0'
+    androidxFragmentVersion = '1.5.6'
+    coreSplashScreenVersion = '1.0.0'
+    androidxWebkitVersion = '1.6.1'
     junitVersion = '4.13.2'
-    androidxJunitVersion = '1.1.3'
-    androidxEspressoCoreVersion = '3.4.0'
+    androidxJunitVersion = '1.1.5'
+    androidxEspressoCoreVersion = '3.5.1'
     cordovaAndroidVersion = '10.1.1'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "999.999.999",
       "hasInstallScript": true,
       "dependencies": {
-        "@capacitor/android": "4.7.3",
-        "@capacitor/core": "4.7.3",
+        "@capacitor/android": "^5.0.0",
+        "@capacitor/core": "^5.0.0",
         "@gtm-support/vue-gtm": "1.2.3",
         "@quasar/extras": "1.10.10",
         "buffer": "6.0.3",
@@ -43,7 +43,7 @@
         "zod-to-json-schema": "3.20.1"
       },
       "devDependencies": {
-        "@capacitor/cli": "4.7.3",
+        "@capacitor/cli": "5.0.3",
         "@openapitools/openapi-generator-cli": "2.3.3",
         "@playwright/test": "1.32.1",
         "@quasar/vite-plugin": "1.3.0",
@@ -143,17 +143,17 @@
       }
     },
     "node_modules/@capacitor/android": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-4.7.3.tgz",
-      "integrity": "sha512-TmVg7vbAt6Iw0FWc51dLlW1gRMtSeIQ6qVLFJ1/sl2SYLXpgCHh8v/LfhqQ93NurgM+6SKFxOycGgg1FIBaLGw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-5.0.3.tgz",
+      "integrity": "sha512-jPN6JJUbN2cCrAjP+0Q4gIwIxleFVChZWh+/gsbDDfSpogdpZNwZnriUNxSRTZayL58tUzLHuxpJxY6hsddDrA==",
       "peerDependencies": {
-        "@capacitor/core": "^4.7.0"
+        "@capacitor/core": "^5.0.0"
       }
     },
     "node_modules/@capacitor/cli": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-4.7.3.tgz",
-      "integrity": "sha512-/9Vjl0A91UjRA0b8a5YCqHfHcM50vQ3Fh0typ3ScwYZhg3shkFtB03e8liAD/u0rhr/MerN8VGgN75QNEXN0Lg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-5.0.3.tgz",
+      "integrity": "sha512-VPmd/uKSCYqeLgNTrG2wVaMoCX8lo2UuXFVwP54W4nXPyG6LsDuOKYytkBItTAJrI3KEXdZWyRFbXjIY48/m6g==",
       "dev": true,
       "dependencies": {
         "@ionic/cli-framework-output": "^2.2.5",
@@ -164,22 +164,31 @@
         "debug": "^4.3.4",
         "env-paths": "^2.2.0",
         "kleur": "^4.1.4",
-        "native-run": "^1.6.0",
+        "native-run": "^1.7.2",
         "open": "^8.4.0",
         "plist": "^3.0.5",
         "prompts": "^2.4.2",
-        "rimraf": "^3.0.2",
+        "rimraf": "^4.4.1",
         "semver": "^7.3.7",
         "tar": "^6.1.11",
         "tslib": "^2.4.0",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.5.0"
       },
       "bin": {
         "cap": "bin/capacitor",
         "capacitor": "bin/capacitor"
       },
       "engines": {
-        "node": ">=12.4.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@capacitor/cli/node_modules/commander": {
@@ -189,6 +198,24 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@capacitor/cli/node_modules/lru-cache": {
@@ -201,6 +228,48 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/rimraf": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@capacitor/cli/node_modules/semver": {
@@ -231,9 +300,9 @@
       "dev": true
     },
     "node_modules/@capacitor/core": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-4.7.3.tgz",
-      "integrity": "sha512-IDhJapHqfJNpSlq89M0quOZGb08uOUZhVhyRDdrGUrwa4ttFoWeX/Vi9F+b9bffsDRKkSLF0BhzA9TH7ko5c3A==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-5.0.3.tgz",
+      "integrity": "sha512-VxzSoFvoiGDmvlKQMbg7ZZh+w3Z223630kZINDOsbs7UZr5gZws7+m26Y9Oc8n2miI737hE6qOf2VU4H/8Tytg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13237,6 +13306,40 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-scurry": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.1.tgz",
+      "integrity": "sha512-UgmoiySyjFxP6tscZDgWGEAgsW5ok8W3F5CJDnnH2pozwSTGE6eH7vwTotMwATWA2r5xqdkKdxYPkwlJjAI/3g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
+      "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.1.tgz",
+      "integrity": "sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/pathe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
@@ -17408,9 +17511,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",
@@ -17604,15 +17707,15 @@
       "integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw=="
     },
     "@capacitor/android": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-4.7.3.tgz",
-      "integrity": "sha512-TmVg7vbAt6Iw0FWc51dLlW1gRMtSeIQ6qVLFJ1/sl2SYLXpgCHh8v/LfhqQ93NurgM+6SKFxOycGgg1FIBaLGw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-5.0.3.tgz",
+      "integrity": "sha512-jPN6JJUbN2cCrAjP+0Q4gIwIxleFVChZWh+/gsbDDfSpogdpZNwZnriUNxSRTZayL58tUzLHuxpJxY6hsddDrA==",
       "requires": {}
     },
     "@capacitor/cli": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-4.7.3.tgz",
-      "integrity": "sha512-/9Vjl0A91UjRA0b8a5YCqHfHcM50vQ3Fh0typ3ScwYZhg3shkFtB03e8liAD/u0rhr/MerN8VGgN75QNEXN0Lg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-5.0.3.tgz",
+      "integrity": "sha512-VPmd/uKSCYqeLgNTrG2wVaMoCX8lo2UuXFVwP54W4nXPyG6LsDuOKYytkBItTAJrI3KEXdZWyRFbXjIY48/m6g==",
       "dev": true,
       "requires": {
         "@ionic/cli-framework-output": "^2.2.5",
@@ -17623,22 +17726,43 @@
         "debug": "^4.3.4",
         "env-paths": "^2.2.0",
         "kleur": "^4.1.4",
-        "native-run": "^1.6.0",
+        "native-run": "^1.7.2",
         "open": "^8.4.0",
         "plist": "^3.0.5",
         "prompts": "^2.4.2",
-        "rimraf": "^3.0.2",
+        "rimraf": "^4.4.1",
         "semver": "^7.3.7",
         "tar": "^6.1.11",
         "tslib": "^2.4.0",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.5.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "commander": {
           "version": "9.5.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
           "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
           "dev": true
+        },
+        "glob": {
+          "version": "9.3.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+          "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "minimatch": "^8.0.2",
+            "minipass": "^4.2.4",
+            "path-scurry": "^1.6.1"
+          }
         },
         "lru-cache": {
           "version": "6.0.0",
@@ -17647,6 +17771,30 @@
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+          "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+          "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+          "dev": true,
+          "requires": {
+            "glob": "^9.2.0"
           }
         },
         "semver": {
@@ -17673,9 +17821,9 @@
       }
     },
     "@capacitor/core": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-4.7.3.tgz",
-      "integrity": "sha512-IDhJapHqfJNpSlq89M0quOZGb08uOUZhVhyRDdrGUrwa4ttFoWeX/Vi9F+b9bffsDRKkSLF0BhzA9TH7ko5c3A==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-5.0.3.tgz",
+      "integrity": "sha512-VxzSoFvoiGDmvlKQMbg7ZZh+w3Z223630kZINDOsbs7UZr5gZws7+m26Y9Oc8n2miI737hE6qOf2VU4H/8Tytg==",
       "requires": {
         "tslib": "^2.1.0"
       },
@@ -28013,6 +28161,30 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-scurry": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.1.tgz",
+      "integrity": "sha512-UgmoiySyjFxP6tscZDgWGEAgsW5ok8W3F5CJDnnH2pozwSTGE6eH7vwTotMwATWA2r5xqdkKdxYPkwlJjAI/3g==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
+          "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
+          "dev": true
+        },
+        "minipass": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.1.tgz",
+          "integrity": "sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw==",
+          "dev": true
+        }
+      }
+    },
     "pathe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
@@ -31226,9 +31398,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "cap:open:ios": "npx cap open ios"
   },
   "dependencies": {
-    "@capacitor/android": "^5.0.0",
-    "@capacitor/core": "^5.0.0",
+    "@capacitor/android": "5.0.3",
+    "@capacitor/core": "5.0.3",
     "@gtm-support/vue-gtm": "1.2.3",
     "@quasar/extras": "1.10.10",
     "buffer": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "cap:open:ios": "npx cap open ios"
   },
   "dependencies": {
-    "@capacitor/android": "4.7.3",
-    "@capacitor/core": "4.7.3",
+    "@capacitor/android": "^5.0.0",
+    "@capacitor/core": "^5.0.0",
     "@gtm-support/vue-gtm": "1.2.3",
     "@quasar/extras": "1.10.10",
     "buffer": "6.0.3",
@@ -74,7 +74,7 @@
     "dmg-license": "1.0.11"
   },
   "devDependencies": {
-    "@capacitor/cli": "4.7.3",
+    "@capacitor/cli": "5.0.3",
     "@openapitools/openapi-generator-cli": "2.3.3",
     "@playwright/test": "1.32.1",
     "@quasar/vite-plugin": "1.3.0",


### PR DESCRIPTION
## 内容
Capacitorを5.0.3に更新します。基本的には`npx cap migrate`をしただけです。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）